### PR TITLE
feat:画像クリックでフルサイズ表示ダイアログを追加

### DIFF
--- a/web/src/app/reviews/[id]/_components/review-content.tsx
+++ b/web/src/app/reviews/[id]/_components/review-content.tsx
@@ -16,6 +16,7 @@ import { Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import ShareButton from '@/components/ui/share-button'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 
 const clampScore = (value?: number | null) =>
   typeof value === 'number' ? Math.max(0, Math.min(5, value)) : 0
@@ -204,15 +205,28 @@ export function ReviewContent({
 
       <div className="mt-6 md:flex md:space-x-6">
         <div className="w-full md:w-1/2">
-          <div className="h-[250px] w-full overflow-hidden rounded-xl shadow-md">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={imageUrl}
-              alt={`${shareTitle}の投稿画像`}
-              className="h-full w-full object-cover"
-              loading="lazy"
-            />
-          </div>
+          <Dialog>
+            <DialogTrigger asChild>
+              <div className="h-[250px] w-full cursor-pointer overflow-hidden rounded-xl shadow-md">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageUrl}
+                  alt={`${shareTitle}の投稿画像`}
+                  className="h-full w-full object-cover transition-opacity hover:opacity-90"
+                  loading="lazy"
+                />
+              </div>
+            </DialogTrigger>
+            <DialogContent className="max-w-3xl border-0 bg-black/90 p-2">
+              <DialogTitle className="sr-only">{shareTitle}の投稿画像</DialogTitle>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imageUrl}
+                alt={`${shareTitle}の投稿画像`}
+                className="max-h-[80vh] w-full object-contain"
+              />
+            </DialogContent>
+          </Dialog>
           <div className="mt-4 flex items-center gap-3 text-sm text-gray-600">
             <Avatar className="h-10 w-10">
               <AvatarFallback

--- a/web/src/app/reviews/_components/review-form.tsx
+++ b/web/src/app/reviews/_components/review-form.tsx
@@ -208,7 +208,6 @@ export const ReviewForm = () => {
               <Select
                 name={field.name}
                 onValueChange={field.onChange}
-                // ★ ここが修正点：undefined にしない（常に string）
                 value={field.value ?? ''}
                 disabled={
                   isPending || brandLoading || brandOptions.length === 0

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -178,7 +178,7 @@ export function Header() {
 
         <div className="flex items-center gap-3">
           {/* PCメニュー */}
-          <div className="hidden md:flex items-center space-x-4">
+          <div className="hidden items-center space-x-4 md:flex">
             {session?.user ? (
               <Menubar className={menubarClass}>
                 <MenubarMenu>
@@ -188,7 +188,10 @@ export function Header() {
                   <MenubarContent className="bg-white text-gray-900">
                     {reviewLinks.map((link) => (
                       <MenubarItem asChild key={link.href}>
-                        <Link href={link.href} className="flex w-full items-center">
+                        <Link
+                          href={link.href}
+                          className="flex w-full items-center"
+                        >
                           {link.label}
                         </Link>
                       </MenubarItem>
@@ -203,7 +206,10 @@ export function Header() {
                   <MenubarContent className="bg-white text-gray-900">
                     {brandLinks.map((link) => (
                       <MenubarItem asChild key={link.href}>
-                        <Link href={link.href} className="flex w-full items-center">
+                        <Link
+                          href={link.href}
+                          className="flex w-full items-center"
+                        >
                           {link.label}
                         </Link>
                       </MenubarItem>
@@ -218,7 +224,10 @@ export function Header() {
                   <MenubarContent className="bg-white text-gray-900">
                     {otherLinks.map((link) => (
                       <MenubarItem asChild key={link.href}>
-                        <Link href={link.href} className="flex w-full items-center">
+                        <Link
+                          href={link.href}
+                          className="flex w-full items-center"
+                        >
                           {link.label}
                         </Link>
                       </MenubarItem>
@@ -236,7 +245,12 @@ export function Header() {
             ) : (
               <div className="flex items-center gap-3">
                 {guestLinks.map((link) => (
-                  <Button asChild size="lg" className={authButtonClass} key={link.href}>
+                  <Button
+                    asChild
+                    size="lg"
+                    className={authButtonClass}
+                    key={link.href}
+                  >
                     <Link href={link.href}>{link.label}</Link>
                   </Button>
                 ))}
@@ -263,7 +277,7 @@ export function Header() {
       </header>
 
       {mobileMenuOpen && (
-        <div className="md:hidden text-slate-900" aria-hidden={!mobileMenuOpen}>
+        <div className="text-slate-900 md:hidden" aria-hidden={!mobileMenuOpen}>
           {/* overlay */}
           <div
             className="fixed inset-0 z-[60] bg-black/40 backdrop-blur-sm"
@@ -291,9 +305,12 @@ export function Header() {
             </div>
 
             {session?.user ? (
-              <nav className="flex flex-1 flex-col gap-6" aria-label="ログイン済みメニュー">
+              <nav
+                className="flex flex-1 flex-col gap-6"
+                aria-label="ログイン済みメニュー"
+              >
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  <p className="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase">
                     レビュー
                   </p>
                   <div className="mt-2 space-y-2">
@@ -311,7 +328,7 @@ export function Header() {
                 </div>
 
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  <p className="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase">
                     メーカー・店舗
                   </p>
                   <div className="mt-2 space-y-2">
@@ -330,7 +347,7 @@ export function Header() {
 
                 {!!otherLinks.length && (
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    <p className="text-xs font-semibold tracking-[0.2em] text-slate-500 uppercase">
                       その他
                     </p>
                     <div className="mt-2 space-y-2">
@@ -357,7 +374,10 @@ export function Header() {
                 </button>
               </nav>
             ) : (
-              <nav className="flex flex-col gap-3" aria-label="未ログインメニュー">
+              <nav
+                className="flex flex-col gap-3"
+                aria-label="未ログインメニュー"
+              >
                 {guestLinks.map((link) => (
                   <Link
                     key={link.href}

--- a/web/src/components/ui/share-button.tsx
+++ b/web/src/components/ui/share-button.tsx
@@ -23,22 +23,14 @@ export default function ShareButton({
 }: ShareButtonProps) {
   const [canShare, setCanShare] = useState(false)
   const [showCopiedMessage, setShowCopiedMessage] = useState(false)
+  const [absoluteUrl, setAbsoluteUrl] = useState(url)
 
   useEffect(() => {
     setCanShare(typeof navigator !== 'undefined' && 'share' in navigator)
-  }, [])
-
-  // urlが相対だった場合に絶対URLに寄せる（保険）
-  const absoluteUrl = useMemo(() => {
     try {
-      return new URL(
-        url,
-        typeof window !== 'undefined'
-          ? window.location.origin
-          : 'https://example.com',
-      ).toString()
+      setAbsoluteUrl(new URL(url, window.location.origin).toString())
     } catch {
-      return url
+      setAbsoluteUrl(url)
     }
   }, [url])
 


### PR DESCRIPTION
## Summary
- レビュー詳細画面の投稿画像をクリックするとフルサイズ表示ダイアログが開くようになった
- ShareButtonのURL絶対パス変換処理を `useMemo` から `useEffect` 内に統合し、ハイドレーションの一貫性を改善

## Test plan
- [ ] レビュー詳細画面で画像をクリックしてダイアログが開くことを確認
- [ ] ダイアログ内でフルサイズ画像が正しく表示されることを確認
- [ ] ダイアログを閉じられることを確認
- [ ] Xシェアボタンが正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Review images can now be clicked to open in a full-screen interactive viewer for better visibility.

* **Style**
  * Minor layout formatting refinements to the header component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->