### PR TITLE
feat: いいね機能の追加

### DIFF
--- a/web/prisma/migrations/20260605032142_add_like_model/migration.sql
+++ b/web/prisma/migrations/20260605032142_add_like_model/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Like" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "reviewId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Like_reviewId_idx" ON "Like"("reviewId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Like_userId_reviewId_key" ON "Like"("userId", "reviewId");
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   role           Role            @default(USER)
   reviews        Review[]
   comments       Comment[]
+  likes          Like[]
   brands         Brand[]
   chocolates     Chocolate[]
   accounts       Account[]
@@ -42,6 +43,7 @@ model Review {
   brand         Brand?     @relation(fields: [brandId], references: [id])
   user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   comments      Comment[]
+  likes         Like[]
   // 場所情報（Google Places）への参照（任意）
   placeId       String?   @db.Uuid
   place         Place?    @relation(fields: [placeId], references: [id])
@@ -58,6 +60,18 @@ model Comment {
   reviewId  String
   review    Review   @relation(fields: [reviewId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
+}
+
+model Like {
+  id        String   @id @default(uuid())
+  userId    String
+  reviewId  String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  review    Review   @relation(fields: [reviewId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+
+  @@unique([userId, reviewId])
+  @@index([reviewId])
 }
 
 model Account {

--- a/web/src/app/actions/like/toggle.ts
+++ b/web/src/app/actions/like/toggle.ts
@@ -29,11 +29,11 @@ export async function toggleLike(reviewId: string): Promise<ActionResult> {
       })
     }
 
-  //   revalidatePath(`/reviews/${reviewId}`)
-  //   revalidatePath('/reviews')
-  //   return { isSuccess: true }
-  // } catch (err) {
-  //   console.error('toggleLike error:', err)
-  //   return { isSuccess: false, errorCode: ErrorCodes.SERVER_ERROR }
+    revalidatePath(`/reviews/${reviewId}`)
+    revalidatePath('/reviews')
+    return { isSuccess: true }
+  } catch (err) {
+    console.error('toggleLike error:', err)
+    return { isSuccess: false, errorCode: ErrorCodes.SERVER_ERROR }
   }
 }

--- a/web/src/app/actions/like/toggle.ts
+++ b/web/src/app/actions/like/toggle.ts
@@ -14,20 +14,20 @@ export async function toggleLike(reviewId: string): Promise<ActionResult> {
 
   const userId = session.user.id
 
-  // try {
-  //   const existing = await prisma.like.findUnique({
-  //     where: { userId_reviewId: { userId, reviewId } },
-  //   })
+  try {
+    const existing = await prisma.like.findUnique({
+      where: { userId_reviewId: { userId, reviewId } },
+    })
 
-  //   if (existing) {
-  //     await prisma.like.delete({
-  //       where: { userId_reviewId: { userId, reviewId } },
-  //     })
-  //   } else {
-  //     await prisma.like.create({
-  //       data: { userId, reviewId },
-  //     })
-  //   }
+    if (existing) {
+      await prisma.like.delete({
+        where: { userId_reviewId: { userId, reviewId } },
+      })
+    } else {
+      await prisma.like.create({
+        data: { userId, reviewId },
+      })
+    }
 
   //   revalidatePath(`/reviews/${reviewId}`)
   //   revalidatePath('/reviews')
@@ -35,5 +35,5 @@ export async function toggleLike(reviewId: string): Promise<ActionResult> {
   // } catch (err) {
   //   console.error('toggleLike error:', err)
   //   return { isSuccess: false, errorCode: ErrorCodes.SERVER_ERROR }
-  // }
+  }
 }

--- a/web/src/app/actions/like/toggle.ts
+++ b/web/src/app/actions/like/toggle.ts
@@ -1,0 +1,39 @@
+'use server'
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { revalidatePath } from 'next/cache'
+import { ActionResult, ErrorCodes } from '@/types'
+
+export async function toggleLike(reviewId: string): Promise<ActionResult> {
+  const session = await auth()
+
+  if (!session?.user) {
+    return { isSuccess: false, errorCode: ErrorCodes.UNAUTHORIZED }
+  }
+
+  const userId = session.user.id
+
+  // try {
+  //   const existing = await prisma.like.findUnique({
+  //     where: { userId_reviewId: { userId, reviewId } },
+  //   })
+
+  //   if (existing) {
+  //     await prisma.like.delete({
+  //       where: { userId_reviewId: { userId, reviewId } },
+  //     })
+  //   } else {
+  //     await prisma.like.create({
+  //       data: { userId, reviewId },
+  //     })
+  //   }
+
+  //   revalidatePath(`/reviews/${reviewId}`)
+  //   revalidatePath('/reviews')
+  //   return { isSuccess: true }
+  // } catch (err) {
+  //   console.error('toggleLike error:', err)
+  //   return { isSuccess: false, errorCode: ErrorCodes.SERVER_ERROR }
+  // }
+}


### PR DESCRIPTION
## 概要
- Likeモデルの追加とマイグレーション
- `toggleLike` Server Actionの実装（いいね追加・解除のトグル）
- レビュー詳細・一覧画面へのいいねボタンUI追加

## 動作確認
- [ ] ログイン済みユーザーがいいねボタンを押すと追加される
- [ ] 再度押すといいねが解除される
- [ ] 未ログイン時はエラーが返る
- [ ] いいね後にレビュー詳細・一覧のキャッシュが再検証される

## 関連issue
#100