### PR TITLE
add: いいね機能の追加とPrisma migrate ワークフロー改善

### DIFF
--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -1,30 +1,68 @@
-name: Prisma Migrate (Production)
+# name: Prisma Migrate (Production)
 
+# on:
+#   workflow_dispatch:
+
+# concurrency:
+#   group: production-db-migrate
+#   cancel-in-progress: false
+
+# jobs:
+#   migrate:
+#     runs-on: ubuntu-latest
+#     environment: production
+
+#     steps:
+#       - uses: actions/checkout@v4
+
+#       - uses: actions/setup-node@v4
+#         with:
+#           node-version: 20
+#           cache: npm
+#           cache-dependency-path: web/package-lock.json
+
+#       - name: Install dependencies
+#         working-directory: web
+#         run: npm ci
+
+#       - name: Prisma migrate deploy
+#         working-directory: web
+#         env:
+#           DIRECT_URL: ${{ secrets.DIRECT_URL }}
+#           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+#         run: npx prisma migrate deploy
+name: Prisma Migrate (Production)
 on:
   workflow_dispatch:
-
+    inputs:
+      resolve_rolled_back:
+        description: "rolled-back 扱いにする失敗マイグレーション名（空なら resolve をスキップ）"
+        required: false
+        default: ""
 concurrency:
   group: production-db-migrate
   cancel-in-progress: false
-
 jobs:
   migrate:
     runs-on: ubuntu-latest
     environment: production
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: web/package-lock.json
-
       - name: Install dependencies
         working-directory: web
         run: npm ci
-
+      - name: Resolve failed migration (rolled-back)
+        if: ${{ github.event.inputs.resolve_rolled_back != '' }}
+        working-directory: web
+        env:
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx prisma migrate resolve --rolled-back "${{ github.event.inputs.resolve_rolled_back }}"
       - name: Prisma migrate deploy
         working-directory: web
         env:

--- a/web/src/app/reviews/[id]/_components/review-content.tsx
+++ b/web/src/app/reviews/[id]/_components/review-content.tsx
@@ -15,6 +15,7 @@ import { ImgEditor } from '@/lib/img-editor'
 import { Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import ShareButton from '@/components/ui/share-button'
+import { LikeButton } from '@/components/ui/like-button'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 
@@ -98,12 +99,14 @@ type ReviewContentProps = {
   review: ReviewWithUser
   currentUserId: string
   currentUserRole: string
+  isLoggedIn?: boolean
 }
 
 export function ReviewContent({
   review,
   currentUserId,
   currentUserRole,
+  isLoggedIn = false,
 }: ReviewContentProps) {
   const lat = review.place?.lat ?? null
   const lng = review.place?.lng ?? null
@@ -269,6 +272,12 @@ export function ReviewContent({
       </div>
 
       <div className="mt-6 flex flex-col gap-3 text-sm text-gray-500 sm:flex-row sm:items-center">
+        <LikeButton
+          reviewId={review.id}
+          initialLikeCount={review.likeCount ?? 0}
+          initialIsLiked={review.isLiked ?? false}
+          isLoggedIn={isLoggedIn}
+        />
         <ShareButton
           url={shareUrl}
           title={shareTitle}

--- a/web/src/app/reviews/[id]/page.tsx
+++ b/web/src/app/reviews/[id]/page.tsx
@@ -15,7 +15,7 @@ export default async function ReviewDetailPage({
   const { id } = await params
   const session = await auth()
 
-  const review = await getReviewById(id)
+  const review = await getReviewById(id, session?.user?.id)
   if (!review) notFound()
 
   const currentUserId = session?.user?.id ?? ''
@@ -28,6 +28,7 @@ export default async function ReviewDetailPage({
           review={review}
           currentUserId={currentUserId}
           currentUserRole={currentUserRole}
+          isLoggedIn={!!session?.user}
         />
 
         <div className="mt-8 border-t border-gray-200 pt-6">

--- a/web/src/app/reviews/_components/review-card.tsx
+++ b/web/src/app/reviews/_components/review-card.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useMemo } from 'react'
-import { Star } from 'lucide-react'
+import { Heart, Star } from 'lucide-react'
 import Image from 'next/image'
 
 import { ReviewWithUser } from '@/types'
@@ -153,6 +153,12 @@ export function ReviewCard({ review, href }: ReviewCardProps) {
             {rating} / 5
           </span>
         </div>
+        {(review.likeCount ?? 0) > 0 && (
+          <div className="flex items-center gap-1 text-xs text-pink-400">
+            <Heart className="h-3.5 w-3.5 fill-pink-400" />
+            <span>{review.likeCount}</span>
+          </div>
+        )}
       </div>
 
       {contentPreview && (

--- a/web/src/app/reviews/page.tsx
+++ b/web/src/app/reviews/page.tsx
@@ -4,9 +4,9 @@ import { auth } from '@/lib/auth'
 
 export default async function ReviewListPage() {
   const session = await auth()
-  const reviews = await getReviews()
   const currentUserId = session?.user?.id ?? ''
   const currentUserRole = session?.user?.role ?? ''
+  const reviews = await getReviews(currentUserId || undefined)
 
   return (
     <main className="mx-auto max-w-6xl space-y-6 p-6">

--- a/web/src/components/ui/like-button.tsx
+++ b/web/src/components/ui/like-button.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Heart } from 'lucide-react'
+import { toggleLike } from '@/app/actions/like/toggle'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+
+type LikeButtonProps = {
+  reviewId: string
+  initialLikeCount: number
+  initialIsLiked: boolean
+  isLoggedIn: boolean
+}
+
+export function LikeButton({
+  reviewId,
+  initialLikeCount,
+  initialIsLiked,
+  isLoggedIn,
+}: LikeButtonProps) {
+  const [isLiked, setIsLiked] = useState(initialIsLiked)
+  const [likeCount, setLikeCount] = useState(initialLikeCount)
+  const [isPending, startTransition] = useTransition()
+
+  const handleClick = () => {
+    if (!isLoggedIn) {
+      toast.error('いいねするにはログインしてください')
+      return
+    }
+
+    const nextIsLiked = !isLiked
+    setIsLiked(nextIsLiked)
+    setLikeCount((prev) => prev + (nextIsLiked ? 1 : -1))
+
+    startTransition(async () => {
+      const result = await toggleLike(reviewId)
+      if (!result.isSuccess) {
+        setIsLiked(isLiked)
+        setLikeCount(likeCount)
+        toast.error('操作に失敗しました')
+      }
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isPending}
+      aria-label={isLiked ? 'いいねを取り消す' : 'いいねする'}
+      className={cn(
+        'flex items-center gap-1.5 rounded-full border px-4 py-2 text-sm font-semibold transition-colors',
+        isLiked
+          ? 'border-pink-300 bg-pink-50 text-pink-500 hover:bg-pink-100'
+          : 'border-gray-200 bg-white text-gray-500 hover:border-pink-200 hover:bg-pink-50 hover:text-pink-400',
+        isPending && 'opacity-60',
+      )}
+    >
+      <Heart
+        className={cn('h-4 w-4', isLiked && 'fill-pink-500 text-pink-500')}
+      />
+      <span>{likeCount}</span>
+    </button>
+  )
+}

--- a/web/src/services/get-review-by-id.ts
+++ b/web/src/services/get-review-by-id.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma'
 
-export async function getReviewById(reviewId: string) {
+export async function getReviewById(reviewId: string, currentUserId?: string) {
   const review = await prisma.review.findUnique({
     where: { id: reviewId },
     include: {
@@ -22,20 +22,33 @@ export async function getReviewById(reviewId: string) {
       place: {
         select: { lat: true, lng: true, address: true, name: true },
       },
+      _count: {
+        select: { likes: true },
+      },
+      ...(currentUserId
+        ? { likes: { where: { userId: currentUserId }, select: { userId: true } } }
+        : {}),
     },
   })
 
   if (!review) return null
 
+  const { _count, likes, ...rest } = review as typeof review & {
+    _count: { likes: number }
+    likes?: { userId: string }[]
+  }
+
   return {
-    ...review,
-    place: review.place
+    ...rest,
+    likeCount: _count.likes,
+    isLiked: currentUserId ? (likes ?? []).length > 0 : false,
+    place: rest.place
       ? {
-          ...review.place,
-          lat: review.place.lat ?? null,
-          lng: review.place.lng ?? null,
-          address: review.place.address ?? null,
-          name: review.place.name ?? null,
+          ...rest.place,
+          lat: rest.place.lat ?? null,
+          lng: rest.place.lng ?? null,
+          address: rest.place.address ?? null,
+          name: rest.place.name ?? null,
         }
       : null,
   }


### PR DESCRIPTION
## 概要
レビューに対するいいね機能を追加しました。あわせて、本番DBで失敗マイグレーションが残った際に手動でrolled-back扱いにできるよう、Prisma migrate ワークフローを拡張しました。

## 主な変更点
以下を変更
- `Like` モデルを追加（`User` / `Review` への複合ユニーク制約付き）し、マイグレーションを追加
- `toggleLike` Server Action を追加（認証チェック + `revalidatePath`）
- `getReviews` / `getReviewById` で `likeCount` / `isLiked` を取得するように変更
- `ReviewWithUser` 型に `likeCount` / `isLiked` を追加
- `LikeButton` コンポーネントを追加し、レビュー一覧カードと詳細画面に統合
- `.github/workflows/migrate-prod.yml` に `resolve_rolled_back` 入力を追加し、失敗マイグレーションをrolled-back扱いにできるステップを追加

## テスト
- ローカルでレビュー一覧 / 詳細からいいねのトグル動作を確認
- 未ログイン時のガード動作を確認

## 関連Issue
#100

